### PR TITLE
chore: update repository URL after up→tx3up rename

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Installer for the tx3 toolchain"
 authors = ["TxPipe <hello@txpipe.com>"]
 license = "Apache-2.0"
-repository = "https://github.com/tx3-lang/up"
+repository = "https://github.com/tx3-lang/tx3up"
 
 [dependencies]
 self-replace = "1.5.0"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Install the latest release with the bootstrap script:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/up/releases/latest/download/tx3up-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh
 ```
 
 Once `tx3up` is on your `PATH`, it manages itself and the rest of the toolchain.


### PR DESCRIPTION
The `tx3-lang/up` repository was renamed to `tx3-lang/tx3up`. This updates the `repository` field in `Cargo.toml` (cargo-dist derives release and installer URLs from it) and the install snippet in the README.

GitHub redirects keep the old URL working, so this is a correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)